### PR TITLE
Append local lib to LOAD_PATH in executable

### DIFF
--- a/bin/divide
+++ b/bin/divide
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
 
+$:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
+
 require 'divide'
 exit Divide.run(ARGV)


### PR DESCRIPTION
This makes sure that if we run `./bin/divide` (after cloning this repository, for instance) it’s going to use the local `./lib/divide` directory first, not the installed gem.
