### PR TITLE
Load .env variables into Procfile

### DIFF
--- a/lib/divide/extractor.rb
+++ b/lib/divide/extractor.rb
@@ -2,15 +2,21 @@ require 'yaml'
 
 module Divide
   class Extractor
+    DEFAULT_ENV = { 'PORT' => '5000' }.merge(ENV)
+
     def initialize(options=[])
       @options = options
 
+      overwrite_env_variables
       overwrite_options
-      overwrite_port
     end
 
     def procfile_content
       @procfile_content ||= File.read('./Procfile') rescue ''
+    end
+
+    def env_content
+      @env_content ||= File.read('./.env') rescue ''
     end
 
     def overwrite_options
@@ -29,13 +35,24 @@ module Divide
       end
     end
 
-    def overwrite_port
-      procfile_content.sub!('$PORT', ENV['PORT'] || '5000')
-    end
-
     def extract_processes!
       return nil if procfile_content.empty?
       YAML.load(procfile_content)
+    end
+
+    def env_variables
+      @env_variables ||= begin
+        env_content.split(/\n/).inject({}) do |memo, line|
+          variable, value = line.split(/=/)
+          memo.merge variable => value
+        end
+      end
+    end
+
+    def overwrite_env_variables
+      DEFAULT_ENV.merge(env_variables).each do |variable, value|
+        procfile_content.gsub!("$#{variable}", value)
+      end
     end
   end
 end


### PR DESCRIPTION
This allows using variables from `.env` files in `Procfile` commands, just like `foreman` does.

```
# ./Procfile
web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb -E $RACK_ENV

# ./.env
RACK_ENV=development
PORT=4008
```
